### PR TITLE
Re-add DiscordRPC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,9 @@ dependencies {
     modCompileOnly("dev.isxander", "yet-another-config-lib", property("deps.yacl").toString())
     modCompileOnly("com.terraformersmc", "modmenu", property("deps.modmenu").toString())
 
-    // Discord IPC (bundle into the mod jar)
+    // Discord IPC
     include(implementation("com.github.jagrosh:DiscordIPC:master-SNAPSHOT")!!)
+    include(implementation("org.json:json:20250517")!!)
 }
 
 // Add placeholder-api dependency if property exists

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
 
     modCompileOnly("dev.isxander", "yet-another-config-lib", property("deps.yacl").toString())
     modCompileOnly("com.terraformersmc", "modmenu", property("deps.modmenu").toString())
+
+    // Discord IPC (bundle into the mod jar)
+    include(implementation("com.github.jagrosh:DiscordIPC:master-SNAPSHOT")!!)
 }
 
 // Add placeholder-api dependency if property exists

--- a/src/main/java/cc/aabss/eventutils/DiscordRPC.java
+++ b/src/main/java/cc/aabss/eventutils/DiscordRPC.java
@@ -1,0 +1,135 @@
+package cc.aabss.eventutils;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.server.integrated.IntegratedServer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.jagrosh.discordipc.IPCClient;
+import com.jagrosh.discordipc.IPCListener;
+import com.jagrosh.discordipc.entities.RichPresence;
+import com.jagrosh.discordipc.entities.pipe.PipeStatus;
+import org.json.JSONObject;
+
+
+public class DiscordRPC {
+    private static final OffsetDateTime START = OffsetDateTime.now();
+
+    @NotNull private final EventUtils mod;
+    @Nullable private ScheduledFuture<?> presenceTask;
+    @Nullable public IPCClient client;
+
+    public DiscordRPC(@NotNull EventUtils mod) {
+        this.mod = mod;
+    }
+
+    public void connect() {
+        if (!mod.config.discordRpc) return;
+        if (client != null && client.getStatus() == PipeStatus.CONNECTED) return;
+
+        client = new IPCClient(1351016544779374735L);
+        client.setListener(new IPCListener() {
+            @Override
+            public void onReady(IPCClient client) {
+                EventUtils.LOGGER.info("DISCORD RPC: Connected");
+                scheduleUpdates();
+            }
+
+            @Override
+            public void onClose(IPCClient client, JSONObject json) {
+                EventUtils.LOGGER.info("DISCORD RPC: Disconnected ({})", json);
+                cancelUpdates();
+            }
+
+            @Override
+            public void onDisconnect(IPCClient client, Throwable t) {
+                EventUtils.LOGGER.warn("DISCORD RPC: Disconnected due to error", t);
+                cancelUpdates();
+            }
+        });
+
+        try {
+            client.connect();
+        } catch (final Exception e) {
+            EventUtils.LOGGER.error("DISCORD RPC: Failed to connect", e);
+            client = null;
+        }
+    }
+
+    public void disconnect() {
+        cancelUpdates();
+        if (client != null) {
+            try {
+                client.close();
+            } catch (Exception ignored) {}
+        }
+        client = null;
+    }
+
+    private void scheduleUpdates() {
+        cancelUpdates();
+        presenceTask = mod.scheduler.scheduleAtFixedRate(this::updatePresence, 0, 10, TimeUnit.SECONDS);
+    }
+
+    private void cancelUpdates() {
+        if (presenceTask != null) {
+            presenceTask.cancel(false);
+            presenceTask = null;
+        }
+    }
+
+    private void updatePresence() {
+        if (!mod.config.discordRpc) return;
+        if (client == null || client.getStatus() != PipeStatus.CONNECTED) return;
+
+        final Status status = Status.get();
+        final String username = MinecraftClient.getInstance().getSession().getUsername();
+        final RichPresence.Builder builder = new RichPresence.Builder()
+                .setState("Currently in " + status.text)
+                .setDetails("Playing as " + username)
+                .setStartTimestamp(START)
+                .setLargeImage("logo", "EventUtils" + (Versions.EU_VERSION != null ? " v" + Versions.EU_VERSION : ""))
+                .setSmallImage("minecraft", "Minecraft" + (Versions.MC_VERSION != null ? " v" + Versions.MC_VERSION : ""));
+
+        // These dont work ig
+//        builder.set("Download the mod!", "https://modrinth.com/mod/alerts");
+//        builder.setButton2("Join the Discord!", "https://discord.gg/aGDuQcduWZ");
+
+        try {
+            client.sendRichPresence(builder.build());
+        } catch (final Exception e) {
+            EventUtils.LOGGER.warn("DISCORD RPC: Failed to update presence", e);
+        }
+    }
+
+    private enum Status {
+        SINGLEPLAYER("Singleplayer"),
+        MULTIPLAYER("Multiplayer"),
+        MAIN_MENU("the Main Menu");
+
+        private final String text;
+
+        Status(String text) {
+            this.text = text;
+        }
+
+        @NotNull
+        private static Status get() {
+            final MinecraftClient client = MinecraftClient.getInstance();
+            final IntegratedServer server = client.getServer();
+            if (server != null && server.isRunning()) return SINGLEPLAYER;
+            final ServerInfo entry = client.getCurrentServerEntry();
+            if (entry != null && entry.address != null && !Objects.equals(entry.address, "")) return MULTIPLAYER;
+            return MAIN_MENU;
+        }
+    }
+}
+
+

--- a/src/main/java/cc/aabss/eventutils/config/ConfigScreen.java
+++ b/src/main/java/cc/aabss/eventutils/config/ConfigScreen.java
@@ -32,6 +32,15 @@ public class ConfigScreen {
             .title(translatable("eventutils.config.title"))
             .category(ConfigCategory.createBuilder().name(translatable("eventutils.config.general"))
                     .option(Option.<Boolean>createBuilder()
+                            .name(translatable("eventutils.config.discord.title"))
+                            .description(OptionDescription.of(translatable("eventutils.config.discord.description")))
+                            .binding(EventConfig.Defaults.DISCORD_RPC, () -> config.discordRpc, newValue -> {
+                                config.discordRpc = newValue;
+                                config.setSave("discord_rpc", config.discordRpc);
+                                if (Boolean.TRUE.equals(newValue)) EventUtils.MOD.discordRPC.connect(); else EventUtils.MOD.discordRPC.disconnect();
+                            })
+                            .controller(ConfigScreen::getBooleanBuilder).build())
+                    .option(Option.<Boolean>createBuilder()
                             .name(translatable("eventutils.config.teleport.title"))
                             .description(OptionDescription.of(translatable("eventutils.config.teleport.description")))
                             .binding(EventConfig.Defaults.AUTO_TP, () -> config.autoTp, newValue -> {


### PR DESCRIPTION
This PR reintroduces the DiscordRPC features dropped in #13. It uses [DiscordIPC](https://github.com/jagrosh/DiscordIPC), a well maintained library for this featureset, and maintains the same content that the mod previously displayed (excluding the buttons which have seemingly been dropped from RPC support).

Fixes #15 