### PR TITLE
Multiversion for 1.21.5 and 1.21.6

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,11 +10,11 @@ stonecutter {
     centralScript = "build.gradle.kts"
     shared {
         versions( // Make sure to update .github/workflows/publish.yml when changing versions!
+            "1.21.6",
+            "1.21.5",
             "1.21.4",
-            "1.21.3",
             "1.21.1",
             "1.21",
-            "1.20.6",
             "1.20.4")
     }
     create(rootProject)

--- a/src/main/java/cc/aabss/eventutils/KeybindManager.java
+++ b/src/main/java/cc/aabss/eventutils/KeybindManager.java
@@ -52,14 +52,16 @@ public class KeybindManager {
             if (windowHandle == null) windowHandle = client.getWindow().getHandle();
 
             // Event info key
-            if (GLFW.glfwGetKey(windowHandle, ((KeyBindingMixin) eventInfoKey).getBoundKey().getCode()) == GLFW.GLFW_PRESS) {
-                if (canNotPress(eventInfoKey)) return;
-                EventUtils.LOGGER.info("Event info key pressed");
-                if (SocketEndpoint.LAST_EVENT != null) {
-                    client.setScreen(new EventInfoScreen(SocketEndpoint.LAST_EVENT));
-                    return;
+            if (!eventInfoKey.isUnbound()) {
+                if (GLFW.glfwGetKey(windowHandle, ((KeyBindingMixin) eventInfoKey).getBoundKey().getCode()) == GLFW.GLFW_PRESS) {
+                    if (canNotPress(eventInfoKey)) return;
+                    EventUtils.LOGGER.info("Event info key pressed");
+                    if (SocketEndpoint.LAST_EVENT != null) {
+                        client.setScreen(new EventInfoScreen(SocketEndpoint.LAST_EVENT));
+                        return;
+                    }
+                    if (client.player != null) client.player.sendMessage(Text.literal("No event has happened recently!").formatted(Formatting.RED), true);
                 }
-                if (client.player != null) client.player.sendMessage(Text.literal("No event has happened recently!").formatted(Formatting.RED), true);
             }
 
             // DEV: Uncomment to force test event

--- a/src/main/java/cc/aabss/eventutils/NotificationToast.java
+++ b/src/main/java/cc/aabss/eventutils/NotificationToast.java
@@ -12,12 +12,8 @@ import net.minecraft.client.toast.ToastManager;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-
-//? if >=1.21.6 {
-
-/*import net.minecraft.client.gl.RenderPipelines;
-
-*///?}
+//? if >=1.21.6
+/*import net.minecraft.client.gl.RenderPipelines;*/
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -93,13 +89,10 @@ public class NotificationToast implements Toast {
         if (width == 160 && lines.size() <= 1) {
             //? if <1.21.2 {
             /*drawContext.drawGuiTexture(TEXTURE, 0, 0, width, height);
-            *///?} else {
-            //? if >=1.21.6 {
+            *///?} else if >=1.21.6 {
             /*drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 0, 0, width, height); // work on 1.21.4 and 1.21.5
             *///?} else {
             drawContext.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 0, 0, width, height); // work on 1.21.4 and 1.21.5
-            
-            //?}
             //?}
         } else {
             int minHeight = Math.min(4, height - 28);
@@ -129,18 +122,14 @@ public class NotificationToast implements Toast {
         /*context.drawGuiTexture(TEXTURE, 160, 32, 0, j, 0, k, m, l);
         for (int o = m; o < widthN; o += 64) context.drawGuiTexture(TEXTURE, 160, 32, 32, j, o, k, Math.min(64, widthN - o), l);
         context.drawGuiTexture(TEXTURE, 160, 32, 160 - n, j, widthN, k, n, l);
-        *///?} else {
-        //? if >=1.21.6 {
+        *///?} else if >=1.21.6 {
         /*context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 160, 32, 0, j, 0, k, m, l);
         for (int o = m; o < widthN; o += 64) context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 160, 32, 32, j, o, k, Math.min(64, widthN - o), l);
         context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 160, 32, 160 - n, j, widthN, k, n, l);
         *///?} else {
-        
         context.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 160, 32, 0, j, 0, k, m, l);
         for (int o = m; o < widthN; o += 64) context.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 160, 32, 32, j, o, k, Math.min(64, widthN - o), l);
         context.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 160, 32, 160 - n, j, widthN, k, n, l);
-        
-        //?}
         //?}
     }
 

--- a/src/main/java/cc/aabss/eventutils/NotificationToast.java
+++ b/src/main/java/cc/aabss/eventutils/NotificationToast.java
@@ -5,13 +5,19 @@ import net.fabricmc.api.Environment;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.toast.Toast;
 import net.minecraft.client.toast.ToastManager;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+
+//? if >=1.21.6 {
+
+/*import net.minecraft.client.gl.RenderPipelines;
+
+*///?}
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -80,15 +86,20 @@ public class NotificationToast implements Toast {
 
     @Override
     //? if <1.21.2 {
-    /*public Toast.Visibility draw(DrawContext drawContext, ToastManager manager, long startTime) {*/
-    //?} else {
+    /*public Toast.Visibility draw(DrawContext drawContext, ToastManager manager, long startTime) {
+    *///?} else {
     public void draw(DrawContext drawContext, TextRenderer textRenderer, long startTime) {
     //?}
         if (width == 160 && lines.size() <= 1) {
             //? if <1.21.2 {
-            /*drawContext.drawGuiTexture(TEXTURE, 0, 0, width, height);*/
-            //?} else {
-            drawContext.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 0, 0, width, height);
+            /*drawContext.drawGuiTexture(TEXTURE, 0, 0, width, height);
+            *///?} else {
+            //? if >=1.21.6 {
+            /*drawContext.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 0, 0, width, height); // work on 1.21.4 and 1.21.5
+            *///?} else {
+            drawContext.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 0, 0, width, height); // work on 1.21.4 and 1.21.5
+            
+            //?}
             //?}
         } else {
             int minHeight = Math.min(4, height - 28);
@@ -119,9 +130,17 @@ public class NotificationToast implements Toast {
         for (int o = m; o < widthN; o += 64) context.drawGuiTexture(TEXTURE, 160, 32, 32, j, o, k, Math.min(64, widthN - o), l);
         context.drawGuiTexture(TEXTURE, 160, 32, 160 - n, j, widthN, k, n, l);
         *///?} else {
+        //? if >=1.21.6 {
+        /*context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 160, 32, 0, j, 0, k, m, l);
+        for (int o = m; o < widthN; o += 64) context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 160, 32, 32, j, o, k, Math.min(64, widthN - o), l);
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, 160, 32, 160 - n, j, widthN, k, n, l);
+        *///?} else {
+        
         context.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 160, 32, 0, j, 0, k, m, l);
         for (int o = m; o < widthN; o += 64) context.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 160, 32, 32, j, o, k, Math.min(64, widthN - o), l);
         context.drawGuiTexture(RenderLayer::getGuiTextured, TEXTURE, 160, 32, 160 - n, j, widthN, k, n, l);
+        
+        //?}
         //?}
     }
 

--- a/src/main/java/cc/aabss/eventutils/UpdateChecker.java
+++ b/src/main/java/cc/aabss/eventutils/UpdateChecker.java
@@ -31,21 +31,21 @@ public class UpdateChecker {
         client.send(() -> {
             if (client.player == null) return;
             //? if >=1.21.5 {
-            client.player.sendMessage(Text.literal("§6[EVENTUTILS]§r §e" + EventUtils.translate("eventutils.updatechecker.new")+"§r §7(v" + Versions.EU_VERSION + " -> v" + latestVersion.replace(Versions.MC_VERSION + "-", "") + ")" + "\n")
+            /*client.player.sendMessage(Text.literal("§6[EVENTUTILS]§r §e" + EventUtils.translate("eventutils.updatechecker.new")+"§r §7(v" + Versions.EU_VERSION + " -> v" + latestVersion.replace(Versions.MC_VERSION + "-", "") + ")" + "\n")
                             .setStyle(Style.EMPTY
                                     .withHoverEvent(new HoverEvent.ShowText(translatable("eventutils.updatechecker.hover")))
                                     .withClickEvent(new ClickEvent.OpenUrl(URI.create("https://modrinth.com/mod/alerts/version/" + latestVersion))))
                             .append(Text.literal("§7§o" + EventUtils.translate("eventutils.updatechecker.config"))
                                     .setStyle(Style.EMPTY.withClickEvent(new ClickEvent.RunCommand("/event utils")))),
                     false);
-            //?} else {
-            /*client.player.sendMessage(Text.literal("§6[EVENTUTILS]§r §e" + EventUtils.translate("eventutils.updatechecker.new")+"§r §7(v" + Versions.EU_VERSION + " -> v" + latestVersion.replace(Versions.MC_VERSION + "-", "") + ")" + "\n")
+            *///?} else {
+            client.player.sendMessage(Text.literal("§6[EVENTUTILS]§r §e" + EventUtils.translate("eventutils.updatechecker.new")+"§r §7(v" + Versions.EU_VERSION + " -> v" + latestVersion.replace(Versions.MC_VERSION + "-", "") + ")" + "\n")
                             .setStyle(Style.EMPTY
                                     .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, translatable("eventutils.updatechecker.hover")))
                                     .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://modrinth.com/mod/alerts/version/" + latestVersion)))
                             .append(Text.literal("§7§o" + EventUtils.translate("eventutils.updatechecker.config"))
                                     .setStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/eventutils config")))),
-                    false);*/
+                    false);
             //?}
         });
     }

--- a/src/main/java/cc/aabss/eventutils/UpdateChecker.java
+++ b/src/main/java/cc/aabss/eventutils/UpdateChecker.java
@@ -30,13 +30,23 @@ public class UpdateChecker {
         final MinecraftClient client = MinecraftClient.getInstance();
         client.send(() -> {
             if (client.player == null) return;
+            //? if >=1.21.5 {
             client.player.sendMessage(Text.literal("§6[EVENTUTILS]§r §e" + EventUtils.translate("eventutils.updatechecker.new")+"§r §7(v" + Versions.EU_VERSION + " -> v" + latestVersion.replace(Versions.MC_VERSION + "-", "") + ")" + "\n")
+                            .setStyle(Style.EMPTY
+                                    .withHoverEvent(new HoverEvent.ShowText(translatable("eventutils.updatechecker.hover")))
+                                    .withClickEvent(new ClickEvent.OpenUrl(URI.create("https://modrinth.com/mod/alerts/version/" + latestVersion))))
+                            .append(Text.literal("§7§o" + EventUtils.translate("eventutils.updatechecker.config"))
+                                    .setStyle(Style.EMPTY.withClickEvent(new ClickEvent.RunCommand("/event utils")))),
+                    false);
+            //?} else {
+            /*client.player.sendMessage(Text.literal("§6[EVENTUTILS]§r §e" + EventUtils.translate("eventutils.updatechecker.new")+"§r §7(v" + Versions.EU_VERSION + " -> v" + latestVersion.replace(Versions.MC_VERSION + "-", "") + ")" + "\n")
                             .setStyle(Style.EMPTY
                                     .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, translatable("eventutils.updatechecker.hover")))
                                     .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://modrinth.com/mod/alerts/version/" + latestVersion)))
                             .append(Text.literal("§7§o" + EventUtils.translate("eventutils.updatechecker.config"))
                                     .setStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/eventutils config")))),
-                    false);
+                    false);*/
+            //?}
         });
     }
 

--- a/src/main/java/cc/aabss/eventutils/mixin/ButtonWidgetMixin.java
+++ b/src/main/java/cc/aabss/eventutils/mixin/ButtonWidgetMixin.java
@@ -4,15 +4,12 @@ import cc.aabss.eventutils.EventUtils;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.*;
-import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.PressableWidget;
-import net.minecraft.client.network.ServerInfo;
-import net.minecraft.client.realms.gui.screen.RealmsMainScreen;
 import net.minecraft.text.Text;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -22,6 +19,8 @@ import static net.minecraft.text.Text.translatable;
 
 @Mixin(ButtonWidget.class)
 public abstract class ButtonWidgetMixin extends PressableWidget {
+    @Shadow public abstract void onPress();
+
     public ButtonWidgetMixin(int i, int j, int k, int l, Text text) {
         super(i, j, k, l, text);
     }
@@ -36,36 +35,10 @@ public abstract class ButtonWidgetMixin extends PressableWidget {
         final Screen current = client.currentScreen;
         client.setScreen(new ConfirmScreen(yes -> {
             if (yes) {
-                disconnect();
+                this.onPress();
                 return;
             }
             client.setScreen(current);
         }, translatable("eventutils.confirm_disconnect.title"), translatable("eventutils.confirm_disconnect.message")));
-    }
-
-    @Unique
-    private void disconnect() {
-        final MinecraftClient client = MinecraftClient.getInstance();
-        if (client == null || client.world == null) return;
-        final TitleScreen titleScreen = new TitleScreen();
-        client.world.disconnect();
-
-        // Singleplayer
-        if (client.isInSingleplayer()) {
-            client.disconnect(new MessageScreen(translatable("menu.savingLevel")));
-            client.setScreen(titleScreen);
-            return;
-        }
-        client.disconnect();
-
-        // Realms
-        final ServerInfo serverInfo = MinecraftClient.getInstance().getCurrentServerEntry();
-        if (serverInfo != null && serverInfo.isRealm()) {
-            client.setScreen(new RealmsMainScreen(titleScreen));
-            return;
-        }
-
-        // Multiplayer
-        client.setScreen(new MultiplayerScreen(titleScreen));
     }
 }

--- a/src/main/java/cc/aabss/eventutils/utility/ConnectUtility.java
+++ b/src/main/java/cc/aabss/eventutils/utility/ConnectUtility.java
@@ -5,6 +5,7 @@ import cc.aabss.eventutils.EventUtils;
 import com.google.gson.JsonObject;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.MessageScreen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
 import net.minecraft.client.network.ServerAddress;
@@ -22,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static net.minecraft.text.Text.translatable;
+
 
 public class ConnectUtility {
     public static void connect(@NotNull String ip) {
@@ -34,7 +37,11 @@ public class ConnectUtility {
         final ServerAddress address = ServerAddress.parse(ip);
         client.execute(() -> {
             try {
+                //? if >=1.21.6 {
+                /*client.disconnect(new MessageScreen(translatable("multiplayer.disconnect.generic")), false);
+                *///?} else {
                 client.disconnect();
+                //?}
 
                 //? if <=1.20.4 {
                 /*ConnectScreen.connect(screen, client, address, new ServerInfo("EventUtils Event Server", ip, ServerInfo.ServerType.OTHER), true);

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,6 +1,6 @@
 plugins { id("dev.kikugie.stonecutter") }
 
-stonecutter active "1.21.4" /* [SC] DO NOT EDIT */
+stonecutter active "1.21.5" /* [SC] DO NOT EDIT */
 
 stonecutter.registerChiseled(tasks.register("chiseledBuild", stonecutter.chiseled) {
     group = "project"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,6 +1,6 @@
 plugins { id("dev.kikugie.stonecutter") }
 
-stonecutter active "1.21.5" /* [SC] DO NOT EDIT */
+stonecutter active "1.21.4" /* [SC] DO NOT EDIT */
 
 stonecutter.registerChiseled(tasks.register("chiseledBuild", stonecutter.chiseled) {
     group = "project"

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -1,6 +1,0 @@
-deps.minecraft=1.20.6
-deps.yarn_mappings=1.20.6+build.3
-deps.fabric_api=0.100.8+1.20.6
-
-deps.yacl=3.6.0+1.20.6-fabric
-deps.modmenu=10.0.0

--- a/versions/1.21.3/gradle.properties
+++ b/versions/1.21.3/gradle.properties
@@ -1,6 +1,0 @@
-deps.minecraft=1.21.3
-deps.yarn_mappings=1.21.3+build.2
-deps.fabric_api=0.114.0+1.21.3
-
-deps.yacl=3.6.0+1.21.2-fabric
-deps.modmenu=12.0.0

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,0 +1,6 @@
+deps.minecraft=1.21.4
+deps.yarn_mappings=1.21.4+build.7
+deps.fabric_api=0.114.0+1.21.4
+
+deps.yacl=3.6.2+1.21.4-fabric
+deps.modmenu=13.0.0-beta.1

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,6 +1,6 @@
-deps.minecraft=1.21.4
-deps.yarn_mappings=1.21.4+build.7
-deps.fabric_api=0.114.0+1.21.4
+deps.minecraft=1.21.5
+deps.yarn_mappings=1.21.5+build.1
+deps.fabric_api=0.128.2+1.21.5
 
-deps.yacl=3.6.2+1.21.4-fabric
-deps.modmenu=13.0.0-beta.1
+deps.yacl=3.7.1+1.21.5-fabric
+deps.modmenu=14.0.0-rc.2

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -1,0 +1,6 @@
+deps.minecraft=1.21.4
+deps.yarn_mappings=1.21.4+build.7
+deps.fabric_api=0.114.0+1.21.4
+
+deps.yacl=3.6.2+1.21.4-fabric
+deps.modmenu=13.0.0-beta.1

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -1,6 +1,6 @@
-deps.minecraft=1.21.4
-deps.yarn_mappings=1.21.4+build.7
-deps.fabric_api=0.114.0+1.21.4
+deps.minecraft=1.21.6
+deps.yarn_mappings=1.21.6+build.1
+deps.fabric_api=0.128.2+1.21.6
 
-deps.yacl=3.6.2+1.21.4-fabric
-deps.modmenu=13.0.0-beta.1
+deps.yacl=3.7.1+1.21.6-fabric
+deps.modmenu=15.0.0-beta.3


### PR DESCRIPTION
remove support for `1.20.6` and `1.21.3`
add support for `1.21.5` and `1.21.6`
i tested each version and it's features and they all worked

also fixes a GL error that floods the logs with the same error each tick when the event info key is unbinded